### PR TITLE
Fix start and end of fetch test for cases step != 1.

### DIFF
--- a/rrd.go
+++ b/rrd.go
@@ -394,7 +394,7 @@ type FetchResult struct {
 	End      time.Time
 	Step     time.Duration
 	DsNames  []string
-	RowLen   int
+	RowCnt   int
 	values   []float64
 }
 

--- a/rrd_c.go
+++ b/rrd_c.go
@@ -415,14 +415,14 @@ func Fetch(filename, cf string, start, end time.Time, step time.Duration) (Fetch
 	}
 	C.free(unsafe.Pointer(cDsNames))
 
-	rowLen := (int(cEnd)-int(cStart))/int(cStep) + 1
-	valuesLen := dsCnt * rowLen
+	rowCnt := (int(cEnd)-int(cStart))/int(cStep) + 1
+	valuesLen := dsCnt * rowCnt
 	values := make([]float64, valuesLen)
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&values)))
 	sliceHeader.Cap = valuesLen
 	sliceHeader.Len = valuesLen
 	sliceHeader.Data = uintptr(unsafe.Pointer(cData))
-	return FetchResult{filename, cf, start, end, step, dsNames, rowLen, values}, nil
+	return FetchResult{filename, cf, start, end, step, dsNames, rowCnt, values}, nil
 }
 
 // FreeValues free values memory allocated by C.

--- a/rrd_test.go
+++ b/rrd_test.go
@@ -108,14 +108,16 @@ func TestAll(t *testing.T) {
 	}
 	fmt.Printf("\n")
 
-	tm := res.Start
-	for row := 0; row < res.RowLen; row++ {
-		tm = tm.Add(res.Step)
-		fmt.Printf("%s / %d", tm, tm.Unix())
+	row := 0
+	for ti := res.Start.Add(res.Step);
+		ti.Before(end) || ti.Equal(end);
+		ti = ti.Add(res.Step) {
+		fmt.Printf("%s / %d", ti, ti.Unix())
 		for i := 0; i < len(res.DsNames); i++ {
 			v := res.ValueAt(i, row)
 			fmt.Printf("\t%e", v)
 		}
 		fmt.Printf("\n")
+		row++
 	}
 }


### PR DESCRIPTION
This is a temporary fix.
We must get the start and end of date range in a more proper way.
I will try again later.
