### PR TITLE
Add base rrdcached support for `graph' and `xport'

### DIFF
--- a/rrd.go
+++ b/rrd.go
@@ -174,6 +174,8 @@ type Grapher struct {
 	imageFormat string
 	interlaced  bool
 
+	daemon string
+
 	args []string
 }
 
@@ -284,6 +286,10 @@ func (g *Grapher) SetBase(base uint) {
 
 func (g *Grapher) SetWatermark(watermark string) {
 	g.watermark = watermark
+}
+
+func (g *Grapher) SetDaemon(daemon string) {
+	g.daemon = daemon
 }
 
 func (g *Grapher) push(cmd string, options []string) {
@@ -405,6 +411,8 @@ func (r *FetchResult) ValueAt(dsIndex, rowIndex int) float64 {
 type Exporter struct {
 	maxRows uint
 
+	daemon string
+
 	args []string
 }
 
@@ -440,6 +448,10 @@ func (e *Exporter) XportDef(vname, label string) {
 
 func (e *Exporter) Xport(start, end time.Time, step time.Duration) (XportResult, error) {
 	return e.xport(start, end, step)
+}
+
+func (e *Exporter) SetDaemon(daemon string) {
+	e.daemon = daemon
 }
 
 type XportResult struct {

--- a/rrd_c.go
+++ b/rrd_c.go
@@ -97,6 +97,8 @@ var (
 	oRightAxis      = C.CString("--right-axis")
 	oRightAxisLabel = C.CString("--right-axis-label")
 
+	oDaemon = C.CString("--daemon")
+
 	oNoLegend = C.CString("-g")
 
 	oLazy = C.CString("-z")
@@ -240,6 +242,9 @@ func (g *Grapher) makeArgs(filename string, start, end time.Time) []*C.char {
 	if g.watermark != "" {
 		args = append(args, oWatermark, C.CString(g.watermark))
 	}
+	if g.daemon != "" {
+		args = append(args, oDaemon, C.CString(g.daemon))
+	}
 	return append(args, makeArgs(g.args)...)
 }
 
@@ -252,6 +257,9 @@ func (e *Exporter) makeArgs(start, end time.Time, step time.Duration) []*C.char 
 	}
 	if e.maxRows != 0 {
 		args = append(args, oMaxRows, utoc(e.maxRows))
+	}
+	if e.daemon != "" {
+		args = append(args, oDaemon, C.CString(e.daemon))
 	}
 	return append(args, makeArgs(e.args)...)
 }


### PR DESCRIPTION
Hi,

I added base support for `rrdcached` daemon parameters.

As today, the support is only added to the `graph` and `xport` commands. I guess it will need some extra changes (embedded `Cache` method) to implement it on `fetch` and `update`.

Let me know if this is ok for you.

Regards,

Vincent
