### PR TITLE
Avoid final garbage value from Fetch()

### DIFF
--- a/rrd_c.go
+++ b/rrd_c.go
@@ -441,7 +441,7 @@ func Fetch(filename, cf string, start, end time.Time, step time.Duration) (Fetch
 	}
 	C.free(unsafe.Pointer(cDsNames))
 
-	rowCnt := (int(cEnd)-int(cStart))/int(cStep) + 1
+	rowCnt := (int(cEnd)-int(cStart))/int(cStep)
 	valuesLen := dsCnt * rowCnt
 	values := make([]float64, valuesLen)
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&values)))


### PR DESCRIPTION
I'm not 100% certain this is the right fix for everyone- I haven't
checked the librrd api or anything, but at least for my use case I
always get one garbage value at the end of my Fetch() results. Taking
out this "+ 1" makes the data match expectations.
