### PR TITLE
Use pkg-config to handle cgo build flags

### DIFF
--- a/rrd_c.go
+++ b/rrd_c.go
@@ -4,7 +4,7 @@ package rrd
 #include <stdlib.h>
 #include <rrd.h>
 #include "rrdfunc.h"
-#cgo LDFLAGS: -lrrd_th
+#cgo pkg-config: librrd
 */
 import "C"
 import (


### PR DESCRIPTION
Hi,

I just made a change in order to use `pkg-config` to handle the various build flags needed by the `cgo` compilation (`CFLAGS`, `LDFLAGS`...).

It helps to build the package with on OSes having `librrd` in a custom location (e.g. rrdtool using `brew` under Mac OS).

Let me know if this PR is ok for you.

Regards
