### PR TITLE
Handle numeric DS names

### DIFF
--- a/rrd_c.go
+++ b/rrd_c.go
@@ -279,7 +279,9 @@ func parseInfoKey(ik string) (kname, kkey string, kid int) {
 	c += o + 1
 	kname = ik[:o] + ik[c+1:]
 	kkey = ik[o+1 : c]
-	if id, err := strconv.Atoi(kkey); err == nil && id >= 0 {
+	if strings.HasPrefix(kname, "ds.") {
+		return
+	} else if id, err := strconv.Atoi(kkey); err == nil && id >= 0 {
 		kid = id
 	}
 	return


### PR DESCRIPTION
Hi,

I just made a change in order to handle fully numeric DS names in RRD entries. By example, having:

```
ds[42].index = 0
ds[42].type = "DERIVE"
ds[42].minimal_heartbeat = 600
ds[42].min = 0.0000000000e+00
ds[42].max = NaN
ds[42].last_ds = "57447256"
ds[42].value = 1.4651162791e+01
ds[42].unknown_sec = 0
```
currently fills `ds.index` map with a lot of `[]interface{}(nil)`.

With the patch, we verify that `kname` doesn't start with `ds.`, avoiding the `Atoi` conversion for `ds.*` entries and keeping the `-1` key id.

Let me know what do you think of this patch.

Regards,