### PR TITLE
Added compatibility for RRDtool 1.3.x, Added missing include

### DIFF
--- a/rrdfunc.c
+++ b/rrdfunc.c
@@ -1,5 +1,10 @@
 #include <stdlib.h>
+#include <string.h>
 #include <rrd.h>
+
+#ifndef __COMPAT_RRDTOOL_13x
+#	define __COMPAT_RRDTOOL_13x
+#endif
 
 char *rrdError() {
 	char *err = NULL;
@@ -36,7 +41,13 @@ char *rrdGraph(rrd_info_t **ret, int argc, char **argv) {
 
 char *rrdInfo(rrd_info_t **ret, char *filename) {
 	rrd_clear_error();
+#ifdef __COMPAT_RRDTOOL_13x
+	//RRDtool 1.3.x does not export rrd_info_r
+	char *argv[2] = {NULL,filename};
+	*ret = rrd_info(2,argv);
+#else
 	*ret = rrd_info_r(filename);
+#endif
 	return rrdError();
 }
 


### PR DESCRIPTION
- Fixed missing include warning (gcc 4.4.7-11 RHEL 6)
- Added compatibility for RRDtool 1.3.x line (RRDtool 1.3.x does not export rrd_info_r)

Reasons:
- RHEL 6 still uses RRDtool 1.3.8 in the default "supported" repositories. RHEL 6 will be supported until 2020 (End of "Production Phase 3", https://access.redhat.com/support/policy/updates/errata).

Check:
- This patch enables the RRDtool 1.3.x workaround PER DEFAULT. Please check if this breaks anything with the 1.4.x line, as I do not have access to any RRDtool 1.4.x

This patch is equivalent to:
https://github.com/bbczeuz/facette/commit/3bf5c15ce7963ce3eea7943f939901bb709f3918
