### PR TITLE
Grapher.AddOptions feature; xport row count fix

### DIFF
--- a/rrd.go
+++ b/rrd.go
@@ -292,6 +292,10 @@ func (g *Grapher) SetDaemon(daemon string) {
 	g.daemon = daemon
 }
 
+func (g *Grapher) AddOptions(options ...string) {
+	g.args = append(g.args, options...)
+}
+
 func (g *Grapher) push(cmd string, options []string) {
 	if len(options) > 0 {
 		cmd += ":" + strings.Join(options, ":")

--- a/rrd_c.go
+++ b/rrd_c.go
@@ -457,7 +457,7 @@ func (r *FetchResult) FreeValues() {
 	C.free(unsafe.Pointer(sliceHeader.Data))
 }
 
-// Values returns copy of internal array of values. 
+// Values returns copy of internal array of values.
 func (r *FetchResult) Values() []float64 {
 	return append([]float64{}, r.values...)
 }
@@ -502,7 +502,7 @@ func (e *Exporter) xport(start, end time.Time, step time.Duration) (XportResult,
 	}
 	C.free(unsafe.Pointer(cLegends))
 
-	rowCnt := (int(cEnd)-int(cStart))/int(cStep) + 1
+	rowCnt := (int(cEnd) - int(cStart)) / int(cStep) //+ 1 // FIXED: + 1 added extra uninitialized value
 	valuesLen := colCnt * rowCnt
 	values := make([]float64, valuesLen)
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&values)))


### PR DESCRIPTION
Hi,
Please review two commits:
1. Grapher.AddOptions allows set arbitrary options like --border or --full-size-mode
2. The row count in rrd_xport.c is: row_cnt = ((*end) - (*start)) / (*step);
Hence +1 is excess  in rowCnt calculations and gives one unassigned value.