### PR TITLE
Fix rowCnt off by one error causing too many values to be read

### DIFF
--- a/rrd_c.go
+++ b/rrd_c.go
@@ -443,7 +443,7 @@ func Fetch(filename, cf string, start, end time.Time, step time.Duration) (Fetch
 	}
 	C.free(unsafe.Pointer(cDsNames))
 
-	rowCnt := (int(cEnd)-int(cStart))/int(cStep) + 1
+	rowCnt := (int(cEnd) - int(cStart)) / int(cStep)
 	valuesLen := dsCnt * rowCnt
 	var values []float64
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&values)))
@@ -504,7 +504,7 @@ func (e *Exporter) xport(start, end time.Time, step time.Duration) (XportResult,
 	}
 	C.free(unsafe.Pointer(cLegends))
 
-	rowCnt := (int(cEnd)-int(cStart))/int(cStep) + 1
+	rowCnt := (int(cEnd) - int(cStart)) / int(cStep)
 	valuesLen := colCnt * rowCnt
 	values := make([]float64, valuesLen)
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&values)))


### PR DESCRIPTION
Fetch and Xport are reading too many values because the rowCnt calculation is adding 1 unnecessarily.