### PR TITLE
Fix compile Error when building on rrdtool 1.9.0

### DIFF
--- a/rrdfunc.c
+++ b/rrdfunc.c
@@ -28,7 +28,7 @@ char *rrdUpdate(const char *filename, const char *template, int argc, const char
 	return rrdError();
 }
 
-char *rrdGraph(rrd_info_t **ret, int argc, char **argv) {
+char *rrdGraph(rrd_info_t **ret, int argc, const char **argv) {
 	rrd_clear_error();
 	*ret = rrd_graph_v(argc, argv);
 	return rrdError();
@@ -46,7 +46,7 @@ char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *
 	return rrdError();
 }
 
-char *rrdXport(int *ret, int argc, char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data) {
+char *rrdXport(int *ret, int argc, const char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data) {
 	rrd_clear_error();
 	*ret = rrd_xport(argc, argv, xsize, start, end, step, col_cnt, legend_v, data);
 	return rrdError();

--- a/rrdfunc.h
+++ b/rrdfunc.h
@@ -3,5 +3,5 @@ extern char *rrdUpdate(const char *filename, const char *template, int argc, con
 extern char *rrdGraph(rrd_info_t **ret, int argc, char **argv);
 extern char *rrdInfo(rrd_info_t **ret, char *filename);
 extern char *rrdFetch(int *ret, char *filename, const char *cf, time_t *start, time_t *end, unsigned long *step, unsigned long *ds_cnt, char ***ds_namv, double **data);
-extern char *rrdXport(int *ret, int argc, char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data);
+extern char *rrdXport(int *ret, int argc, const char **argv, int *xsize, time_t *start, time_t *end, unsigned long *step, unsigned long *col_cnt, char ***legend_v, double **data);
 extern char *arrayGetCString(char **values, int i);


### PR DESCRIPTION
When compiling, I saw the following error:
expected 'const char **' but argument is of type 'char **'

These errors were introduced in rrdtool commit b76e3c5 (in v1.9.0)

Changing these two function calls to use `const char **` fixes the build issues